### PR TITLE
Minor fix for B-field tracing

### DIFF
--- a/psipy/tracing/tracing.py
+++ b/psipy/tracing/tracing.py
@@ -55,7 +55,7 @@ class FortranTracer:
         from streamtracer import VectorGrid
 
         # Account for tracing in spherical coordinates
-        bs.loc[..., "bp"] /= np.cos(bs.coords["theta"])
+        bs.loc[..., "bp"] /= np.abs(np.cos(bs.coords["theta"]))
         bs.loc[..., "bp"] /= bs.coords["r"]
         bs.loc[..., "bt"] /= bs.coords["r"]
 


### PR DESCRIPTION
The conversion at line-58 of psipy/tracing/tracing.py will have extreme value at theta=pi/2 and -pi/2

In MAS-output, the coordinate extends slightly out of -pi/2:

```
>>> 1/np.cos(bp.theta_coords[0])
-11438666.206416423
```

The coordinate for the tracing equations is defined in (-pi/2, pi/2),
added an `np.abs` for the normalization.